### PR TITLE
[FIX] room response upon gameStatus #22 #43 

### DIFF
--- a/src/services/roomService.ts
+++ b/src/services/roomService.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { QueryTypes } from 'sequelize';
 import GameStatusType from '../@types/GameStatusType';
 import WinConditionType from '../@types/WinConditionType';

--- a/src/services/roomService.ts
+++ b/src/services/roomService.ts
@@ -61,7 +61,6 @@ const getMyRoomList = async (userId: number) => {
               newRoomObj.profit = profit;
             }
           });
-          delete newRoomObj.winCondition;
           return newRoomObj;
         }
         case GameStatusType.COMPLETED: {
@@ -70,14 +69,10 @@ const getMyRoomList = async (userId: number) => {
           const myHistory: any = gameHistory.filter((e: any) => e.roomId === room.id);
           newRoomObj.profit = myHistory[0].profit;
           newRoomObj.rank = myHistory[0].rank;
-          delete newRoomObj.winCondition;
           return newRoomObj;
         }
         default:
-          // eslint-disable-next-line no-case-declarations
-          const newRoomObj: any = { ...room };
-          delete newRoomObj.winCondition;
-          return newRoomObj;
+          return room;
       }
     });
     const data = await Promise.all(promises);

--- a/src/services/roomService.ts
+++ b/src/services/roomService.ts
@@ -1,10 +1,15 @@
+/* eslint-disable no-param-reassign */
 import { QueryTypes } from 'sequelize';
 import GameStatusType from '../@types/GameStatusType';
 import WinConditionType from '../@types/WinConditionType';
+import calculateProfits from '../game/calculator';
 import sequelize from '../models';
 import Room from '../models/Room';
 import UserStock from '../models/UserStock';
 import generateInvitationCode from '../utils/generateInvitationCode';
+import { currentStockPrices } from '../utils/stocks';
+import userGameHistoryService from './userGameHistoryService';
+import userStockService from './userStockService';
 
 const createRoom = async (
   title: string,
@@ -38,10 +43,43 @@ const createRoom = async (
 };
 
 const getMyRoomList = async (userId: number) => {
-  const myRoomList = await sequelize.query(
-    `SELECT r.id, r.title, r.startDate, r.endDate, r.gameStatus FROM room as r INNER JOIN user_stock as u ON r.id = u.roomId WHERE u.userId=${userId}`,
+  const roomList: Array<Room> = await sequelize.query(
+    `SELECT r.id, r.winCondition, r.title, r.startDate, r.endDate, r.gameStatus FROM room as r INNER JOIN user_stock as u ON r.id = u.roomId WHERE u.userId=${userId}`,
     { type: QueryTypes.SELECT },
   );
+
+  const addRoomInfo = async () => {
+    const promises = roomList.map(async (room) => {
+      switch (room.gameStatus) {
+        case GameStatusType.IN_PROGRESS: {
+          const newRoomObj: any = { ...room };
+          const userStocks = await userStockService.getUserStockByRoomId(room.id);
+          const profits = calculateProfits(userStocks, room.winCondition, currentStockPrices);
+          userStocks.forEach((userStock) => {
+            if (userStock.userId === userId) {
+              const index = profits.findIndex((el) => el.id === userStock.id);
+              const { profit } = profits[index];
+              newRoomObj.profit = profit;
+            }
+          });
+          return newRoomObj;
+        }
+        case GameStatusType.COMPLETED: {
+          const newRoomObj: any = { ...room };
+          const gameHistory = await userGameHistoryService.getGameHistory(userId);
+          const myHistory: any = gameHistory.filter((e: any) => e.roomId === room.id);
+          newRoomObj.profit = myHistory[0].profit;
+          newRoomObj.rank = myHistory[0].rank;
+          return newRoomObj;
+        }
+        default:
+          return room;
+      }
+    });
+    const data = await Promise.all(promises);
+    return data;
+  };
+  const myRoomList = addRoomInfo();
   return myRoomList;
 };
 

--- a/src/services/roomService.ts
+++ b/src/services/roomService.ts
@@ -58,7 +58,9 @@ const getMyRoomList = async (userId: number) => {
             if (userStock.userId === userId) {
               const index = profits.findIndex((el) => el.id === userStock.id);
               const { profit } = profits[index];
+              const rank = profits.findIndex((el) => el.profit === profit) + 1;
               newRoomObj.profit = profit;
+              newRoomObj.rank = rank;
             }
           });
           return newRoomObj;

--- a/src/services/roomService.ts
+++ b/src/services/roomService.ts
@@ -62,6 +62,7 @@ const getMyRoomList = async (userId: number) => {
               newRoomObj.profit = profit;
             }
           });
+          delete newRoomObj.winCondition;
           return newRoomObj;
         }
         case GameStatusType.COMPLETED: {
@@ -70,10 +71,14 @@ const getMyRoomList = async (userId: number) => {
           const myHistory: any = gameHistory.filter((e: any) => e.roomId === room.id);
           newRoomObj.profit = myHistory[0].profit;
           newRoomObj.rank = myHistory[0].rank;
+          delete newRoomObj.winCondition;
           return newRoomObj;
         }
         default:
-          return room;
+          // eslint-disable-next-line no-case-declarations
+          const newRoomObj: any = { ...room };
+          delete newRoomObj.winCondition;
+          return newRoomObj;
       }
     });
     const data = await Promise.all(promises);

--- a/src/services/userGameHistoryService.ts
+++ b/src/services/userGameHistoryService.ts
@@ -4,14 +4,14 @@ import sequelize from '../models';
 const findGameHistory = async (userId: number) => {
   const history = await sequelize.query(
     `SELECT ugh.id, ugh.isWin, ugh.rank, ugh.profit,
-    r.winCondition, r.title,  r.startDate, r.endDate,
+    r.id as roomId, r.winCondition, r.title,  r.startDate, r.endDate,
     us.ticker
     FROM user_game_history AS ugh
     LEFT JOIN room AS r
     ON ugh.roomId=r.id
     LEFT JOIN user_stock AS us
     ON ugh.roomId=us.roomId
-    WHERE us.userId=${userId};`,
+    WHERE ugh.userId=${userId} AND us.userId=${userId};`,
     { type: QueryTypes.SELECT },
   );
   return history;


### PR DESCRIPTION
### Issue Number

close #43 


### 작업 내역

> 구현 내용 및 작업 했던 내역

- GET /room 에서 rank, profit 정보를 보내줄 수 있게 수정
- 게임 시작 전 : 둘 다 x
- 게임 중, 종료 : rank, profit

### PR 특이 사항
> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Game status 가 in progress 일 때 profit 를 저렇게 구하는게 맞는지, 더 좋은 방법 있다면 커멘트 남겨주세요~

### CHECKLIST

- [x] Merge하는 브랜치가 올바른가?
- [x] 적절한 Label을 달았는가?
- [x] 올라간 커밋 메시지가 규칙에 맞게 작성되었는가?
